### PR TITLE
Responses are displayed in a list on Screen

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,14 +8,13 @@ function App() {
   const saveResponse = newResponse => {
     setSavedResponses([newResponse, ...savedResponses]);
   };
-  console.log(savedResponses);
 
   return (
     <div id="app">
       <h1>Fun With AI</h1>
       <Form saveResponse={saveResponse} />
       <h2>Responses:</h2>
-      <Responses />
+      <Responses savedResponses={savedResponses} />
     </div>
   );
 }

--- a/src/components/Response.js
+++ b/src/components/Response.js
@@ -1,10 +1,10 @@
-const Response = () => {
+const Response = ({ prompt, response }) => {
   return (
     <li className="response">
       <div className="category">Prompt:</div>
-      <p className="q-and-a">What's the best programming language?</p>
+      <p className="q-and-a">{prompt}</p>
       <div className="category">Response:</div>
-      <p className="q-and-a">There is no such thing bro!</p>
+      <p className="q-and-a">{response}</p>
     </li>
   );
 };

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -1,11 +1,16 @@
 import Response from './Response';
 
-const Responses = () => {
+const Responses = ({ savedResponses }) => {
+  if (savedResponses.length < 1) return <p>No responses yet!</p>;
   return (
     <ul id="responses">
-      <Response />
-      <Response />
-      <Response />
+      {savedResponses.map(response => (
+        <Response
+          prompt={response.prompt}
+          response={response.response}
+          key={response.date}
+        />
+      ))}
     </ul>
   );
 };


### PR DESCRIPTION
## Description
In This PR, I have implemented displaying responses in a list on screen from the OpenAI api. The list is ordered from newest to oldest. Refreshing the browser will wipe out the list of responses as of now, being there is no persistent data storage of responses.

## Related Issue
closes #4 

## Acceptance Criteria
- Results are displayed in a list, sorted from newest to oldest.
- Each result should include the original prompt and a response from the API.

## ScreenShots of UI
| Before Submit | After Submit |
| -------------- | -------------|
| <img width="785" alt="Screen Shot 2022-05-12 at 11 48 46 AM" src="https://user-images.githubusercontent.com/61766455/168148152-95e1ae49-8826-44c7-a065-463af8d8f29e.png"> | <img width="777" alt="Screen Shot 2022-05-12 at 11 49 06 AM" src="https://user-images.githubusercontent.com/61766455/168148216-77b12275-6759-461d-b3af-e95b8ca67927.png"> |

## QA
Pull down branch and run app. Type out something in the text area of the form and submit. You should see a response populated in the response list."

