### PR TITLE
implement browser local storage for responses

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,13 +1,21 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Form from './components/Form';
 import Responses from './components/Responses';
 
 function App() {
-  const [savedResponses, setSavedResponses] = useState([]);
+  const [savedResponses, setSavedResponses] = useState(
+    localStorage.getItem('responses')
+      ? JSON.parse(localStorage.getItem('responses'))
+      : []
+  );
 
   const saveResponse = newResponse => {
     setSavedResponses([newResponse, ...savedResponses]);
   };
+
+  useEffect(() => {
+    localStorage.setItem('responses', JSON.stringify(savedResponses));
+  }, [savedResponses]);
 
   return (
     <div id="app">


### PR DESCRIPTION
## Description
In this PR, browser local storage has been implemented in order to save responses in the the responses list section of the app. The user is able to close the browser window or refresh the page, and the responses will persist in the app.

## Related Issue
closes #5 

## Acceptance Criteria
- User can submit a form and receive a response from api
- User can refresh or close browser, and the original response persists in responses section of the app

##QA/Testing
Pull down branch and start app. Type something in the form and submit. You should see a response in the responses section of the app. Now, refresh the browser window. The response should still be there after refresh.