### PR TITLE
Implement deleting a response from list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "framer-motion": "^6.3.3",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
+        "react-icons": "^4.3.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       }
@@ -13508,6 +13509,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -25860,6 +25869,12 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "react-icons": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.3.1.tgz",
+      "integrity": "sha512-cB10MXLTs3gVuXimblAdI71jrJx8njrJZmNMEMC+sQu5B/BIOmlsAjskdqpn81y8UBVEGuHODd7/ci5DvoSzTQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "framer-motion": "^6.3.3",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
+    "react-icons": "^4.3.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,14 @@ function App() {
     setSavedResponses([newResponse, ...savedResponses]);
   };
 
+  const deleteResponse = id => {
+    if (window.confirm(`Are you sure you want to delete response?`)) {
+      setSavedResponses(
+        savedResponses.filter(response => response.date !== id)
+      );
+    }
+  };
+
   useEffect(() => {
     localStorage.setItem('responses', JSON.stringify(savedResponses));
   }, [savedResponses]);
@@ -23,7 +31,10 @@ function App() {
       <Header />
       <Form saveResponse={saveResponse} />
       <h2>Responses:</h2>
-      <Responses savedResponses={savedResponses} />
+      <Responses
+        savedResponses={savedResponses}
+        deleteResponse={deleteResponse}
+      />
     </div>
   );
 }

--- a/src/components/Response.js
+++ b/src/components/Response.js
@@ -1,8 +1,13 @@
-const Response = ({ prompt, response }) => {
+import { FaTimes } from 'react-icons/fa';
+
+const Response = ({ prompt, response, date, deleteResponse }) => {
   return (
     <li className="response">
       <div className="category">Prompt:</div>
       <p className="q-and-a">{prompt}</p>
+      <button className="btn-delete" onClick={() => deleteResponse(date)}>
+        <FaTimes />
+      </button>
       <div className="category">Response:</div>
       <p className="q-and-a">{response}</p>
     </li>

--- a/src/components/Responses.js
+++ b/src/components/Responses.js
@@ -1,7 +1,7 @@
 import { motion, AnimatePresence } from 'framer-motion';
 import Response from './Response';
 
-const Responses = ({ savedResponses }) => {
+const Responses = ({ savedResponses, deleteResponse }) => {
   if (savedResponses.length < 1)
     return <p className="response-message">No responses yet!</p>;
   return (
@@ -20,7 +20,9 @@ const Responses = ({ savedResponses }) => {
             <Response
               prompt={response.prompt}
               response={response.response}
+              date={response.date}
               key={response.date}
+              deleteResponse={deleteResponse}
             />
           </motion.div>
         ))}

--- a/src/index.css
+++ b/src/index.css
@@ -96,12 +96,20 @@ li.response {
   border-radius: 5px;
   background-color: #eee;
   display: grid;
-  grid-template-columns: 1fr 3fr;
+  grid-template-columns: 1fr 3fr 0.5fr;
   grid-gap: 1rem;
 }
 
 li.response .category {
   font-weight: bold;
+}
+
+.btn-delete {
+  width: 20px;
+  height: 20px;
+  border: 0;
+  cursor: pointer;
+  justify-self: right;
 }
 
 @media screen and (min-width: 900px) {


### PR DESCRIPTION
## Description
In This PR, deleting a response has been implemented. Each response now has a delete button, and clicking the button runs a newly created `deleteResponse` function. The useEffect hook runs after this delete function runs because it updates the state that is a dependency in the useEffect hook. Finally, an npm package called `react icons` has been installed for the delete button.

## Related Issue
closes #14 

## Acceptance Criteria
- User can click on the 'x' icon and have a confirm window appear
- If user confirms delete, the response is deleted and removed from the list
- Refreshing the page does not make the response reappear because it has also been removed from local storage

## Screen Shots
| Delete Button | Confirm Window |
| -------------- | ---------------- |
| <img width="907" alt="Screen Shot 2022-05-13 at 3 39 04 PM" src="https://user-images.githubusercontent.com/61766455/168397943-cd89a860-30aa-458c-8642-3c60ab730aa4.png"> | <img width="870" alt="Screen Shot 2022-05-13 at 3 38 56 PM" src="https://user-images.githubusercontent.com/61766455/168397956-077d3a59-1dfa-4b84-badc-5b31cb43e08c.png"> |

## QA
Pull down branch. Run `npm install` to install dependencies. Run app and add create some responses if you don't already have some in the list. Click the 'x' icon in a response to delete. The response should be removed from the list and should not reappear if you refresh your browser window.

